### PR TITLE
fix Android AV1 black screen

### DIFF
--- a/android/app/src/main/kotlin/com/limelight/jujostream/native_bridge/VideoDecoderRenderer.kt
+++ b/android/app/src/main/kotlin/com/limelight/jujostream/native_bridge/VideoDecoderRenderer.kt
@@ -99,6 +99,13 @@ class VideoDecoderRenderer(
     private val pendingFrames = LinkedBlockingDeque<PendingFrame>(8)
     @Volatile private var vsyncPresenterThread: Thread? = null
 
+    private fun requiresCodecConfigSubmission(): Boolean {
+        return when (StreamConstants.mimeTypeForFormat(videoFormat)) {
+            "video/avc", "video/hevc" -> true
+            else -> false
+        }
+    }
+
     fun setup(videoFormat: Int, width: Int, height: Int, redrawRate: Int): Int {
         this.videoFormat = videoFormat
         this.initialWidth = width
@@ -618,7 +625,7 @@ class VideoDecoderRenderer(
                         BUFFER_TYPE_SPS -> { synchronized(csdLock) { spsBuffer = csdArray }; return DR_OK }
                         BUFFER_TYPE_PPS -> { synchronized(csdLock) { ppsBuffer = csdArray }; return DR_OK }
                     }
-                } else {
+                } else if (requiresCodecConfigSubmission()) {
                     if (!submitCsdBuffers()) return DR_NEED_IDR
                     submittedCsd = true
                 }


### PR DESCRIPTION
## Summary
- only submit codec-config buffers for codecs that actually require them
- allow AV1 IDR picture data to be queued directly instead of blocking on nonexistent SPS/PPS/VPS-style config buffers

## Why
On affected Android devices, AV1 streams could negotiate successfully but never render because the decoder path kept requesting codec config buffers that AV1 did not provide in this flow. That left audio working while video stayed black.